### PR TITLE
New url 4 php binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@ $ ./waf build-shared</pre>
         <div class="description">
           <h3>php-git (PHP bindings)</h3>
           <p>libgit2 bindings for PHP5, maintained by Shuhei Tanuma</p>
-          <a class="button" href="https://github.com/chobie/php-git">Get php-git</a>
+          <a class="button" href="https://github.com/libgit2/php-git">Get php-git</a>
         </div>
       </div>
 


### PR DESCRIPTION
The repo url has changed, as mentioned on https://github.com/chobie/php-git/commit/c46c3b980dc49401fc94e434ea1f9c0413dc56bb
