### PR TITLE
Removing trailing '$'

### DIFF
--- a/api.html
+++ b/api.html
@@ -119,7 +119,7 @@ char out[40];
 
 git_oid_mkraw(&oid, raw);
 git_oid_fmt(out, &oid);
-printf("SHA hex string: %s\n", out);$
+printf("SHA hex string: %s\n", out);
 </pre>
 
 <br/>


### PR DESCRIPTION
There is a trailing '$' in one of the C example blocks.
