### PR TITLE
Add parrot-libgit2

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,17 @@ $ cmake .. </pre>
 
       <div class="bullet">
         <div class="description">
+          <h3>parrot-libgit2 (Parrot Virtual Machine bindings)</h3>
+          <p>
+          parrot-libgit2 are bindings to Parrot VM, which allows all languages running on Parrot access to the libgit2 API.
+          </p>
+          <a class="button" href="https://github.com/letolabs/parrot-libgit2">Get parrot-libgit2</a>
+        </div>
+      </div>
+    </div>
+
+      <div class="bullet">
+        <div class="description">
           <h3>Geef (Erlang bindings)</h3>
           <p>
           Geef is an example of an Erlang NIF binding to libgit2.  Outdated.
@@ -224,6 +235,7 @@ $ cmake .. </pre>
         </div>
       </div>
     </div>
+
 
 
   </div></div>


### PR DESCRIPTION
This adds links and a blurb about parrot-libgit2.
