### PR TITLE
Point the go bindings to the org's git2go

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
             <img src="images/libgit2/logo-go@2x.png" />
             <h6>Go</h6>
             <h5>
-              <a href="https://github.com/str1ngs/go-git">go-git</a>
+              <a href="https://github.com/libgit2/git2go">git2go</a>
             </h5>
           </li>
           <li>


### PR DESCRIPTION
Maybe not straight away, but when we feel they're at least as usable as the binding it currently points to.
