### PR TITLE
Alternative navigation styling

### DIFF
--- a/css/libgit2.css
+++ b/css/libgit2.css
@@ -195,6 +195,27 @@ header #tagline em {
   letter-spacing: 1px;
 }
 
+.navigation ul {
+  list-style-type: none;
+  float: right;
+  margin-top: 28px;
+}
+
+.navigation li {
+  display: inline;
+  margin-left: 24px;
+}
+
+.navigation a {
+  color: #4e443c;
+  font-weight: bold;
+  font-size: 18px;
+}
+
+.navigation a:hover {
+  color: #f14e32;
+}
+
 aside nav ul {
   list-style: none;
   font-size: 16px;

--- a/getting-started.html
+++ b/getting-started.html
@@ -23,15 +23,15 @@
     </a>
     <div class='inner'>
       <header>
+        <nav class="navigation">
+          <ul>
+            <li><a href="http://libgit2.github.com/libgit2/">API Reference</a></li>
+            <li><a href="getting-started.html">Getting Started</a></li>
+            <li><a href="https://github.com/libgit2/libgit2">Source on GitHub</a></li>
+          </ul>
+        </nav>
+
         <a href="index.html"><img src="images/libgit2/logo@2x.png" width="269" height="66" alt="libgit2" /></a>
-        <a href="http://libgit2.github.com/libgit2/" class="button">
-          <img src="images/libgit2/icon-book@2x.png" width="21" height="30" />
-          <h3>API Reference</h3>
-        </a>
-        <a href="getting-started.html" class="button button2">
-          <img src="images/libgit2/icon-book@2x.png" width="21" height="30" />
-          <h3>Getting Started</h3>
-        </a>
       </header>
     </div>
     <div class='inner'>

--- a/index.html
+++ b/index.html
@@ -18,20 +18,17 @@
     </script>
   </head>
   <body id='home'>
-    <a href="https://github.com/libgit2/libgit2" id="github">
-      <img alt="Fork me on GitHub" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" />
-    </a>
     <div class='inner'>
       <header>
+        <nav class="navigation">
+          <ul>
+            <li><a href="http://libgit2.github.com/libgit2/">API Reference</a></li>
+            <li><a href="getting-started.html">Getting Started</a></li>
+            <li><a href="https://github.com/libgit2/libgit2">Source on GitHub</a></li>
+          </ul>
+        </nav>
+
         <a href="index.html"><img src="images/libgit2/logo@2x.png" width="269" height="66" alt="libgit2" /></a>
-        <a href="http://libgit2.github.com/libgit2/" class="button">
-			  <img src="images/libgit2/icon-book@2x.png" width="21" height="30" />
-			  <h3>API Reference</h3>
-        </a>
-        <a href="getting-started.html" class="button button2">
-			  <img src="images/libgit2/icon-book@2x.png" width="21" height="30" />
-			  <h3>Getting Started</h3>
-        </a>
       </header>
     </div>
     <div class='inner'>


### PR DESCRIPTION
As discussed in #26, here is an alternative idea for the top links. Since we're moving on from just a single link, I don't think it makes sense to continue with the button pattern. This pull basically adds a traditional navbar with 3 links (removing the GitHub banner in favor of the extra nav item). If we go with this, the nav labels can be renamed as you guys think makes sense.

Screenshot
![screen shot 2013-10-03 at 2 33 04 pm](https://f.cloud.github.com/assets/6104/1264405/8072e28c-2c5f-11e3-9ccd-e0437d60db05.png)

/cc @ben @vmg
