### PR TITLE
Use protocol-neutral typekit URL

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <!--[if (gte IE 6)&(lte IE 8)]>
       <script src='/javascripts/selectivizr-min.js' type='text/javascript'></script>
     <![endif]-->
-    <script src="http://use.typekit.com/jsq2fql.js" type="text/javascript"></script>
+    <script src="//use.typekit.com/jsq2fql.js" type="text/javascript"></script>
     <script>
       //<![CDATA[
         try{Typekit.load();}catch(e){}


### PR DESCRIPTION
Chrome gives this error when visiting the site right now:

> [blocked] The page at 'https://libgit2.github.com/' was loaded over HTTPS, but ran insecure content from 'http://use.typekit.com/jsq2fql.js': this content should also be loaded over HTTPS.

This fixes that, and should make the fonts and wrapping not look like shite.

![image](https://cloud.githubusercontent.com/assets/39902/4691149/e88819c6-5708-11e4-98af-402da0a55995.png)

Safari treats this as a warning, but loads Typekit anyways. This is what it _should_ look like:

![image](https://cloud.githubusercontent.com/assets/39902/4691153/082041aa-5709-11e4-8c9d-1418217e2e63.png)
