### PR TITLE
Changed node-gitteh to nodegit

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ layout: default
 		<img src="images/libgit2/logo-nodejs@2x.png" />
 		<h6>Node.js</h6>
 		<h5>
-			<a href="https://github.com/libgit2/node-gitteh">node-gitteh</a>
+			<a href="https://github.com/nodegit/nodegit">nodegit</a>
 		</h5>
 		</li>
 		<li>


### PR DESCRIPTION
Current, node-gitteh doesn't have any active maintainers and hasn't had any major updates in a while. NodeGit has just had a major update where we updated to the latest libgit2 release (0.21.2) and also has 3 active maintainers (me, @tbranyen, and @maxkorp).

I think that this would help people use libgit2 inside of nodejs with a more active library and more libgit2 functionality than they currently have.

Thoughts?
