### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@ layout: default
 		<img src="images/libgit2/logo-qt@2x.png" />
 		<h6>C++ Qt</h6>
 		<h5>
-			<a href="https://projects.kde.org/projects/playground/libs/libqgit2/">libqgit2</a>
+			<a href="https://quickgit.kde.org/?p=libqgit2.git">libqgit2</a>
 		</h5>
 		</li>
 		<li>


### PR DESCRIPTION
libqgit2 is not in 'playground' anymore, so url has to be corrected

Fixes #61 