### PR TITLE
config: exclude [vendor] site_templates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,3 @@
 markdown: kramdown
 exclude: ['Readme.md']
+exclude: [vendor]


### PR DESCRIPTION
w/o this, I get:
```
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.1.0/gems/jekyll-3.3.1/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```

on a new install.

see: https://github.com/jekyll/jekyll/issues/2938