### PR TITLE
Updated method to return in credential callback

### DIFF
--- a/docs/guides/authentication/index.md
+++ b/docs/guides/authentication/index.md
@@ -79,6 +79,6 @@ int credentials_cb(git_cred **out, const char *url, const char *username_from_ur
         return GIT_EUSER;
     }
 
-	return git_cred_plaintext_new(out, user, pass);
+	return git_cred_userpass_plaintext_new(out, user, pass);
 }
 ~~~


### PR DESCRIPTION
It seems that `git_cred_plaintext_new` was removed at some point (I haven't found when the change was done) and the alternative is using `git_cred_userpass_plaintext_new`