### PR TITLE
Correcting build and link docs for static_crt and threadsafe

### DIFF
--- a/docs/guides/build-and-link/index.md
+++ b/docs/guides/build-and-link/index.md
@@ -52,10 +52,10 @@ Here are some of the most useful:
 | `BUILD_SHARED_LIBS` | This defaults to `ON`, which produces dynamic libraries (DLLs on Windows). Set it to `OFF` if you want the build to generate static libraries. |
 | `CMAKE_BUILD_TYPE` | This selects the build configuration; available options are `Debug` (the default), `Release`, and `RelWithDebInfo`. In the case of Visual Studio and other multi-configuration project systems, this selects the default build configuration. |
 | `BUILD_CLAR` | Selects whether the unit-test suite is built. This defaults to `ON`; set to `OFF` for a faster build. |
-| `THREADSAFE` | Selects whether libgit2 tries to be threadsafe. This defaults to `OFF`, but unless you **know** your application will only be single-threaded, it's recommended you turn it `ON`. |
+| `THREADSAFE` | Selects whether libgit2 tries to be threadsafe. This defaults to `ON`, unless you **know** your application will only be single-threaded, it's recommended you leave it `ON`. |
 | `LIBGIT2_FILENAME` | Sets the basename of the output binary. For example, if this is set to `foo`, the output will be something like `foo.dll` or `foo.so`. This option is useful to know what version of libgit2 was built, if your build system doesn't embed that information into the binary. |
 | `STDCALL` | *(MSVC Only)* By default, libgit2 builds with the `cdecl` calling convention.  If you're working with Win32 or the CLR, set this to `ON` to build with the `stdcall` convention. |
-| `STATIC_CRT` | *(MSVC Only)* By default, libgit2 will link to a DLL version of the C runtime. Set this to `ON` if you want the runtime functions linked statically. |
+| `STATIC_CRT` | *(MSVC Only)* libgit2 will link the static CRT libraries. This defaults to `ON`  |
 
 Take a look at the [`CMakeLists.txt`](https://github.com/libgit2/libgit2/blob/master/CMakeLists.txt) file for more information.
 


### PR DESCRIPTION
This pr corrects the docs for static_crt & threadsafe as mentioned in https://github.com/libgit2/libgit2/issues/4893