### PR TITLE
docs/guides: fix broken link

### DIFF
--- a/docs/guides/101-samples/index.md
+++ b/docs/guides/101-samples/index.md
@@ -1809,8 +1809,7 @@ fetch_opts.callbacks.payload = &d;
 int error = git_remote_fetch(remote, NULL, &fetch_opts, NULL);
 ~~~
 
-For an example of the credentials callback in action, check out [the network example](https://github.com/libgit2/libgit2/blob/master/examples/network/common.c),
-or the built-in [credential helpers](https://github.com/libgit2/libgit2/blob/master/src/transports/cred_helpers.c).
+For a credentials example, check out [the fetch example](https://github.com/libgit2/libgit2/blob/master/examples/fetch.c#L78), which uses an [interactive credential callback](https://github.com/libgit2/libgit2/blob/master/examples/common.c#L354). See also the built-in [credential helpers](https://github.com/libgit2/libgit2/blob/master/src/transports/cred_helpers.c).
 
 (
   [`git_remote_stop`](http://libgit2.github.com/libgit2/#HEAD/group/remote/git_remote_stop),


### PR DESCRIPTION
While we're here, spruce up the text a bit.

Fixes #91