### PR TITLE
Delete freenode.txt

### DIFF
--- a/freenode.txt
+++ b/freenode.txt
@@ -1,1 +1,0 @@
-AfarboocjaufJifyewjorkireatlot


### PR DESCRIPTION
Since Freenode is dead, and libgit2/libgit2 says the IRC channel is on Libera now. Just happened to spot this and figured someone might as well clean it up.

RIP Freenode :'(